### PR TITLE
feat: add 'json' alias for to_json filter

### DIFF
--- a/src/orchestrator/core/template_manager.py
+++ b/src/orchestrator/core/template_manager.py
@@ -282,6 +282,7 @@ class TemplateManager:
             'truncate_words': truncate_words,
             'regex_search': regex_search,
             'to_json': to_json,
+            'json': to_json,
             'from_json': from_json,
             'date': date_format,
             'markdown_format': markdown_format,


### PR DESCRIPTION
Problem: The TemplateManager was missing a 'json' filter, which caused template rendering errors

Solution: Added a 'json' : to_json filter in template_manager.py so that both | json and | to_json produce the same output

Acceptance Criteria: 
-  Pipelines can use both | json and | to_json.
- Both filters produce identical JSON output.
- No breaking changes to existing pipelines.