### PR TITLE
One run, one identity — owned rather than conjured

### DIFF
--- a/src/orchestrator/core/runtime_context.py
+++ b/src/orchestrator/core/runtime_context.py
@@ -32,6 +32,7 @@ string into somebody's report -- which is what an open namespace would do.
 
 from __future__ import annotations
 
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -66,15 +67,48 @@ BARE_RUNTIME_NAMES: FrozenSet[str] = frozenset(
 )
 
 
+def new_execution_id(pipeline_id: Optional[str] = None) -> str:
+    """An identifier no two runs share.
+
+    This was ``f"{pipeline.id}_{int(time.time())}"``, which is unique only
+    until the same pipeline is started twice inside one second -- routine
+    under a test suite, a scheduler, or a retry loop. Two runs then shared an
+    id, and since that id names checkpoints and stamps artifacts, the second
+    run resumed from the first one's checkpoint.
+
+    The second-resolution stamp is kept because it sorts and reads well; the
+    uniqueness comes from the entropy after it.
+    """
+    stamp = int(time.time())
+    entropy = uuid.uuid4().hex[:8]
+    if pipeline_id:
+        return f"{pipeline_id}_{stamp}_{entropy}"
+    return f"run-{stamp}-{entropy}"
+
+
 @dataclass(frozen=True)
 class RuntimeContext:
-    """One run's identity and start time. Immutable, created once."""
+    """One run's identity and start time. Immutable, created once.
+
+    Created by whoever owns the run -- an orchestrator, an engine, a
+    `PipelineExecutionState`. Context dictionaries receive a *projection* of
+    it (see `project_into`) and never establish it themselves, because a
+    dictionary cannot know whether it is the run or merely a copy of part of
+    it. `PipelineExecutionState.get_available_context` proved the difference:
+    it built a fresh dict per call and let the identity be established inside
+    it, so every read of the run's context invented a new run.
+    """
 
     id: str
     started_at: datetime
+    pipeline_id: Optional[str] = None
 
     @classmethod
-    def create(cls, execution_id: Optional[str] = None) -> "RuntimeContext":
+    def create(
+        cls,
+        execution_id: Optional[str] = None,
+        pipeline_id: Optional[str] = None,
+    ) -> "RuntimeContext":
         """A context for a run starting now, in UTC.
 
         UTC rather than local time so two machines running the same pipeline
@@ -82,8 +116,9 @@ class RuntimeContext:
         change does not go backwards.
         """
         return cls(
-            id=execution_id or f"run-{uuid.uuid4().hex[:12]}",
+            id=execution_id or new_execution_id(pipeline_id),
             started_at=datetime.now(timezone.utc),
+            pipeline_id=pipeline_id,
         )
 
     @property
@@ -111,6 +146,63 @@ class RuntimeContext:
         }
 
 
+    def public_names(self) -> Dict[str, Any]:
+        """Exactly the names the pipeline language declares, and no others.
+
+        One builder for every engine. Each used to assemble its own idea of
+        what a run offers, so `{{ execution.timestamp }}` worked under the
+        main orchestrator and not the declarative engine, `{{ timestamp }}`
+        the reverse, and two engines offered a `pipeline` namespace that
+        validation refuses. The language a pipeline is written against must
+        not depend on which engine happens to run it.
+        """
+        namespace = self.as_template_namespace()
+        names: Dict[str, Any] = {
+            RUNTIME_NAMESPACE: namespace,
+            "execution_id": self.id,
+            "timestamp": namespace["started_at"],
+        }
+        if self.pipeline_id is not None:
+            names["pipeline_id"] = self.pipeline_id
+        return names
+
+    def project_into(self, context: MutableMapping[str, Any]) -> Dict[str, str]:
+        """Write this run's public names into a context dict.
+
+        Idempotent: the values come from an immutable object, so projecting
+        twice writes the same thing twice. Returns the `execution` namespace
+        for callers that want it directly.
+        """
+        namespace = self.as_template_namespace()
+        context[CONTEXT_KEY] = namespace
+        context.update(self.public_names())
+        return namespace
+
+
+def runtime_context_for(context: MutableMapping[str, Any]) -> RuntimeContext:
+    """The run a context dict belongs to, established on first ask.
+
+    For callers that hold a run's context but not the object -- a control
+    system, an engine mid-run. The identity is stored back on the dict, so
+    every later caller holding that same dict gets the same run.
+
+    `PipelineExecutionState` deliberately does not use this: it *is* the run
+    owner and holds a `RuntimeContext` directly.
+    """
+    cached = context.get(CONTEXT_KEY)
+    if isinstance(cached, dict) and EXECUTION_FIELDS <= set(cached):
+        return RuntimeContext(
+            id=cached["id"],
+            started_at=datetime.fromisoformat(cached["started_at"]),
+            pipeline_id=context.get("pipeline_id"),
+        )
+
+    return RuntimeContext.create(
+        execution_id=context.get("execution_id"),
+        pipeline_id=context.get("pipeline_id"),
+    )
+
+
 def execution_namespace_for(context: MutableMapping[str, Any]) -> Dict[str, str]:
     """The run's answer, computed on the first ask and reused after.
 
@@ -118,10 +210,4 @@ def execution_namespace_for(context: MutableMapping[str, Any]) -> Dict[str, str]
     hold without threading an instance through every caller -- and every
     caller already holds the run's context dict.
     """
-    cached = context.get(CONTEXT_KEY)
-    if isinstance(cached, dict) and EXECUTION_FIELDS <= set(cached):
-        return cached
-
-    namespace = RuntimeContext.create(context.get("execution_id")).as_template_namespace()
-    context[CONTEXT_KEY] = namespace
-    return namespace
+    return runtime_context_for(context).project_into(context)

--- a/src/orchestrator/engine/control_flow_engine.py
+++ b/src/orchestrator/engine/control_flow_engine.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Set
 from datetime import datetime
 
 from ..core.pipeline import Pipeline
+from ..core.runtime_context import execution_namespace_for
 from ..core.task import Task, TaskStatus
 from ..compiler.control_flow_compiler import ControlFlowCompiler
 from ..control_flow import (
@@ -90,12 +91,13 @@ class ControlFlowEngine:
         self.step_results.clear()
         self.skipped_tasks.clear()
 
-        # Add pipeline info to context
-        context["pipeline"] = {
-            "id": pipeline.id,
-            "name": pipeline.name,
-            "version": pipeline.version,
-        }
+        # The run's public names: `pipeline_id`, `execution_id`, `timestamp`
+        # and the `execution` namespace. This engine used to offer a
+        # `pipeline` namespace instead, which no other engine populates and
+        # which validation refuses -- so a pipeline using it ran here and
+        # could not be validated anywhere.
+        context.setdefault("pipeline_id", pipeline.id)
+        execution_namespace_for(context)
 
         # Execute tasks
         start_time = datetime.now()

--- a/src/orchestrator/engine/declarative_engine.py
+++ b/src/orchestrator/engine/declarative_engine.py
@@ -113,22 +113,22 @@ class DeclarativePipelineEngine:
         """Initialize execution context with pipeline configuration and inputs."""
         context = {
             "inputs": inputs,
-            "pipeline": {
-                "name": pipeline_spec.name,
-                "version": pipeline_spec.version,
-                "description": pipeline_spec.description,
-            },
             "config": pipeline_spec.config,
-            "execution": {},  # filled in below, once the dict exists to carry it
+            "pipeline_id": pipeline_spec.name,
         }
 
         # Add input values directly to context for easy template access
         context.update(inputs)
 
-        # One answer per run, shared with every other engine. This used to
-        # offer `start_time` and no `timestamp` at all, so `{{ execution.timestamp }}`
-        # rendered here and nowhere else.
-        context["execution"] = execution_namespace_for(context)
+        # One answer per run, and the same names every other engine offers.
+        # This used to supply `start_time` and no `timestamp`, so
+        # `{{ execution.timestamp }}` rendered here and nowhere else, and none
+        # of the bare names (`pipeline_id`, `execution_id`, `timestamp`)
+        # existed at all. It also supplied a `pipeline` namespace that no
+        # other engine populates and that validation refuses, so a pipeline
+        # written against it could not be validated -- see
+        # `runtime_context.public_names` for the language it replaces.
+        execution_namespace_for(context)
 
         return context
 

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -28,7 +28,11 @@ from .state.langgraph_state_manager import LangGraphGlobalContextManager
 from .state.legacy_compatibility import LegacyStateManagerAdapter
 from .core.exceptions import PipelineExecutionError
 from .runtime import RuntimeResolutionIntegration
-from .core.runtime_context import execution_namespace_for
+from .core.runtime_context import (
+    execution_namespace_for,
+    new_execution_id,
+    runtime_context_for,
+)
 
 # Import checkpointing components for Issue #205
 try:
@@ -270,7 +274,7 @@ class Orchestrator:
         Raises:
             ExecutionError: If execution fails
         """
-        execution_id = f"{pipeline.id}_{int(time.time())}"
+        execution_id = new_execution_id(pipeline.id)
 
         # Issue #205: Check if automatic checkpointing should be used
         if self.use_automatic_checkpointing and checkpoint_enabled:
@@ -299,21 +303,22 @@ class Orchestrator:
         
         # Initialize template manager context with pipeline parameters and execution metadata
         self.template_manager.clear_context()
-        self.template_manager.register_context("pipeline_id", pipeline.id)
-        self.template_manager.register_context("execution_id", execution_id)
-        
+
         # What the run knows about itself. Created here, once, and read
-        # everywhere else -- see core/runtime_context.py.
-        execution_namespace = execution_namespace_for(context)
-        self.template_manager.register_context("execution", execution_namespace)
-        # `{{ timestamp }}` is the same instant under a bare name.
-        # `TemplateManager._setup_base_context` seeds it from the clock when the
-        # manager is *constructed*, which is neither the run's start nor the
-        # same value as `execution.timestamp`; the run's own answer wins.
-        self.template_manager.register_context(
-            "timestamp", execution_namespace["started_at"]
-        )
-        
+        # everywhere else -- see core/runtime_context.py. `public_names` is
+        # the single builder every engine uses, so a pipeline is written
+        # against one language rather than against whichever engine runs it.
+        # It supplies `pipeline_id`, `execution_id`, `timestamp` and the
+        # `execution` namespace; `{{ timestamp }}` is the run's start under a
+        # bare name, overriding the clock reading that
+        # `TemplateManager._setup_base_context` takes when the *manager* is
+        # constructed -- neither the run's start nor the same instant as
+        # `execution.timestamp`.
+        runtime = runtime_context_for(context)
+        runtime.project_into(context)
+        for name, value in runtime.public_names().items():
+            self.template_manager.register_context(name, value)
+
         # Register all pipeline context (including inputs)
         for key, value in pipeline.context.items():
             self.template_manager.register_context(key, value)

--- a/src/orchestrator/runtime/execution_state.py
+++ b/src/orchestrator/runtime/execution_state.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional, Set, Tuple
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import json
 import copy
-from ..core.runtime_context import execution_namespace_for
+from ..core.runtime_context import RuntimeContext, new_execution_id
 
 logger = logging.getLogger(__name__)
 
@@ -115,8 +115,17 @@ class PipelineExecutionState:
             pipeline_id: Unique identifier for this pipeline execution
         """
         self.pipeline_id = pipeline_id
-        self.start_time = datetime.now()
-        
+        # This state *is* the run, so it owns the run's identity rather than
+        # letting each reader establish one. `get_available_context` used to
+        # build a fresh dict per call and let the identity be created inside
+        # it; the dict was discarded on return, so every read invented a new
+        # run and reported a different start time:
+        #
+        #     first:  2026-08-03T23:15:17.116698+00:00
+        #     second: 2026-08-03T23:15:17.117053+00:00
+        self.runtime_context = RuntimeContext.create(pipeline_id=pipeline_id)
+        self.start_time = self.runtime_context.started_at
+
         # Core state storage
         self.global_context = {
             'variables': {},      # User-defined and system variables
@@ -297,16 +306,17 @@ class PipelineExecutionState:
                 parent = parent.parent_context
                 depth += 1
         
-        # Add system variables
-        context['pipeline_id'] = self.pipeline_id
-        context['execution_time'] = (datetime.now() - self.start_time).total_seconds()
-        # The run's start time, not a fresh reading. `{{ timestamp }}` and
-        # `{{ execution.timestamp }}` name the same instant and disagreed:
-        # this returned local time without a zone while the run context
-        # returned UTC.
-        context['timestamp'] = execution_namespace_for(context)['started_at']
-        
+        # Add system variables. `pipeline_id`, `execution_id`, `timestamp`
+        # and the `execution` namespace all come from the run this state owns,
+        # so repeated reads agree with each other and with every other engine.
+        self.runtime_context.project_into(context)
+        context['execution_time'] = self._elapsed_seconds()
+
         return context
+
+    def _elapsed_seconds(self) -> float:
+        """How long the run has been going, in seconds."""
+        return (datetime.now(timezone.utc) - self.start_time).total_seconds()
     
     def add_unresolved_item(self, item: UnresolvedItem) -> None:
         """
@@ -478,7 +488,7 @@ class PipelineExecutionState:
         """
         return {
             'pipeline_id': self.pipeline_id,
-            'duration_seconds': (datetime.now() - self.start_time).total_seconds(),
+            'duration_seconds': self._elapsed_seconds(),
             'tasks_executed': len(self.executed_tasks),
             'tasks_pending': len(self.pending_tasks),
             'tasks_failed': len(self.failed_tasks),
@@ -498,6 +508,11 @@ class PipelineExecutionState:
         """
         return {
             'pipeline_id': self.pipeline_id,
+            # The run's identity travels with its state. Without it a resumed
+            # run is a different run: new id, new start time, so the artifacts
+            # written after the checkpoint are stamped differently from the
+            # ones written before it.
+            'execution_id': self.runtime_context.id,
             'start_time': self.start_time.isoformat(),
             'global_context': copy.deepcopy(self.global_context),
             'loop_contexts': {
@@ -537,7 +552,18 @@ class PipelineExecutionState:
             state_dict: State dictionary to import
         """
         self.pipeline_id = state_dict.get('pipeline_id', 'imported')
-        self.start_time = datetime.fromisoformat(state_dict['start_time'])
+        started_at = datetime.fromisoformat(state_dict['start_time'])
+        if started_at.tzinfo is None:
+            # A checkpoint written before start times carried a zone. It was
+            # local time; reading it as UTC keeps the arithmetic working and
+            # is the only interpretation available.
+            started_at = started_at.replace(tzinfo=timezone.utc)
+        self.runtime_context = RuntimeContext(
+            id=state_dict.get('execution_id') or new_execution_id(self.pipeline_id),
+            started_at=started_at,
+            pipeline_id=self.pipeline_id,
+        )
+        self.start_time = self.runtime_context.started_at
         self.global_context = copy.deepcopy(state_dict.get('global_context', {}))
         
         # Reconstruct loop contexts

--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -30,10 +30,13 @@ import pytest
 
 from orchestrator.core.runtime_context import (
     BARE_RUNTIME_NAMES,
+    CONTEXT_KEY,
     EXECUTION_FIELDS,
     RUNTIME_NAMESPACE,
     RuntimeContext,
     execution_namespace_for,
+    new_execution_id,
+    runtime_context_for,
 )
 
 pytestmark = [pytest.mark.contract]
@@ -350,3 +353,207 @@ def test_a_name_the_runtime_does_not_provide_is_still_refused(name, tmp_path):
         f"{name} runs after all; it should be declared rather than refused"
     )
     assert _cli("validate", pipeline, tmp_path).returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# The run owns its identity; dictionaries only receive projections of it
+# ---------------------------------------------------------------------------
+
+def _state(pipeline_id="p"):
+    from orchestrator.runtime.execution_state import PipelineExecutionState
+
+    return PipelineExecutionState(pipeline_id=pipeline_id)
+
+
+def test_reading_a_run_s_context_twice_does_not_start_a_second_run():
+    """The defect this section exists for.
+
+    `get_available_context` built a fresh dict per call and let the run's
+    identity be established *inside it*, then returned the dict and dropped
+    the cache with it. So every read invented a new run::
+
+        first:  2026-08-03T23:15:17.116698+00:00
+        second: 2026-08-03T23:15:17.117053+00:00
+
+    A context dict cannot tell whether it is the run or a copy of part of it,
+    so it is the wrong owner. The state is the run and holds the object.
+    """
+    state = _state()
+    first, second = state.get_available_context(), state.get_available_context()
+
+    assert first["timestamp"] == second["timestamp"], (
+        f"one run reported two start times: {first['timestamp']!r} then "
+        f"{second['timestamp']!r}"
+    )
+    assert first["execution_id"] == second["execution_id"], (
+        f"one run reported two identities: {first['execution_id']!r} then "
+        f"{second['execution_id']!r}"
+    )
+    assert first["execution"] == second["execution"]
+
+
+def test_a_run_s_context_stays_json_serializable():
+    """Checkpointing writes it out; an object in there fails the whole run."""
+    json.dumps(_state().get_available_context())
+
+
+def test_elapsed_time_is_measurable_against_the_run_s_start():
+    """`start_time` became timezone-aware when it became the run's own.
+
+    Subtracting an aware datetime from a naive one raises `TypeError`, so
+    this is the arithmetic that would break silently at the two call sites
+    that measure duration.
+    """
+    state = _state()
+    assert state.get_available_context()["execution_time"] >= 0
+    assert state.get_execution_summary()["duration_seconds"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# A resumed run is the same run
+# ---------------------------------------------------------------------------
+
+def test_a_checkpoint_round_trip_preserves_the_run(tmp_path):
+    """Export, restore, and it is still the same run.
+
+    The identity was not exported at all, so a resumed run got a new id and a
+    new start time -- the artifacts written after the checkpoint stamped
+    differently from the ones written before it, in the one situation where
+    you most want to line them up.
+    """
+    original = _state()
+    before = original.get_available_context()
+
+    exported = json.loads(json.dumps(original.export_state()))  # as it travels
+    restored = _state(pipeline_id="something-else")
+    restored.import_state(exported)
+    after = restored.get_available_context()
+
+    assert after["execution_id"] == before["execution_id"]
+    assert after["timestamp"] == before["timestamp"]
+    assert after["execution"] == before["execution"]
+
+
+def test_a_checkpoint_written_before_start_times_had_a_zone_still_loads():
+    """Older checkpoints hold a naive local `start_time`.
+
+    Reading one must not leave the state unable to subtract its own start
+    time from the clock.
+    """
+    from datetime import datetime as _datetime
+
+    state = _state()
+    exported = state.export_state()
+    exported["start_time"] = _datetime.now().isoformat()  # naive, as before
+    exported.pop("execution_id")
+
+    state.import_state(exported)
+    assert state.get_execution_summary()["duration_seconds"] >= 0
+    assert state.get_available_context()["execution_id"]
+
+
+# ---------------------------------------------------------------------------
+# Two runs are two runs
+# ---------------------------------------------------------------------------
+
+def test_ids_generated_in_one_second_are_distinct():
+    """`f"{pipeline.id}_{int(time.time())}"` is unique only until a pipeline
+    starts twice inside one second -- routine under a test suite, a scheduler
+    or a retry loop. The id names checkpoints, so a collision means the second
+    run resumes from the first one's state.
+    """
+    ids = {new_execution_id("same-pipeline") for _ in range(5000)}
+    assert len(ids) == 5000, f"{5000 - len(ids)} of 5000 ids collided"
+
+
+def test_an_id_still_names_its_pipeline():
+    """Uniqueness must not cost traceability: the id is read in logs."""
+    assert new_execution_id("my-pipeline").startswith("my-pipeline_")
+
+
+def test_two_states_are_two_runs():
+    assert (
+        _state().get_available_context()["execution_id"]
+        != _state().get_available_context()["execution_id"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# One language, whichever engine runs it
+# ---------------------------------------------------------------------------
+
+def test_the_builder_emits_exactly_the_declared_language():
+    """`public_names` is the contract every engine is held to.
+
+    If it drifts from what the validators accept, an engine offers a name no
+    pipeline may use, or a declared name no engine populates -- both of which
+    this namespace has done.
+    """
+    names = RuntimeContext.create(execution_id="x", pipeline_id="p").public_names()
+
+    assert set(names) == BARE_RUNTIME_NAMES | {RUNTIME_NAMESPACE}
+    assert set(names[RUNTIME_NAMESPACE]) == EXECUTION_FIELDS
+
+
+def test_projection_is_idempotent():
+    """Engines project defensively, sometimes more than once per run."""
+    runtime = RuntimeContext.create(execution_id="x", pipeline_id="p")
+    context = {}
+    runtime.project_into(context)
+    first = dict(context)
+    runtime.project_into(context)
+    assert context == first
+
+
+def test_a_context_that_already_knows_its_run_does_not_start_another():
+    context = {"execution_id": "abc", "pipeline_id": "p"}
+    execution_namespace_for(context)
+    recovered = runtime_context_for(context)
+
+    assert recovered.id == "abc"
+    assert recovered.as_template_namespace() == context[CONTEXT_KEY]
+
+
+def test_the_declarative_engine_offers_the_same_names_as_everyone_else():
+    """It offered `start_time` and no `timestamp`, so `{{ execution.timestamp }}`
+    rendered under the main orchestrator and nowhere else."""
+    from orchestrator.engine.declarative_engine import DeclarativePipelineEngine
+    from orchestrator.engine.pipeline_spec import PipelineSpec
+
+    spec = PipelineSpec(
+        name="p", steps=[{"id": "s", "action": "generate", "inputs": {}}]
+    )
+    context = DeclarativePipelineEngine()._initialize_context(spec, {"topic": "x"})
+
+    assert BARE_RUNTIME_NAMES <= set(context), (
+        f"the declarative engine does not populate "
+        f"{sorted(BARE_RUNTIME_NAMES - set(context))}"
+    )
+    assert set(context[RUNTIME_NAMESPACE]) == EXECUTION_FIELDS
+    assert context["timestamp"] == context[RUNTIME_NAMESPACE]["started_at"]
+
+
+def test_no_engine_offers_a_namespace_validation_refuses():
+    """`pipeline` was populated by two engines and refused by the validators.
+
+    A pipeline written against it ran on those engines and could not be
+    validated anywhere -- the contract described one engine, not the product.
+    `context` and `env` are refused on the same grounds.
+    """
+    import re
+
+    refused = ("pipeline", "context", "env")
+    pattern = re.compile(
+        r"""context\[\s*['"](""" + "|".join(refused) + r""")['"]\s*\]\s*="""
+    )
+
+    offenders = [
+        f"{path.relative_to(REPO)}:{i}: {line.strip()}"
+        for path in (REPO / "src" / "orchestrator").rglob("*.py")
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if pattern.search(line)
+    ]
+    assert not offenders, (
+        "these populate a namespace the validators refuse, so a pipeline "
+        f"using it cannot be validated: {offenders}"
+    )


### PR DESCRIPTION
Four defects in the "one run, one context" contract, all reproduced before being fixed.

## 1. Every read of a run's context started a new run

`PipelineExecutionState.get_available_context` built a fresh dict per call and let the run's identity be established *inside it*, then returned the dict and dropped the cache with it:

```
first:  2026-08-03T23:15:17.116698+00:00
second: 2026-08-03T23:15:17.117053+00:00
```

The root cause is ownership, not caching. A context dict cannot know whether it is the run or a copy of part of it, so it is the wrong place to establish identity. `PipelineExecutionState` **is** the run and now holds a `RuntimeContext`; dictionaries receive projections of it.

`runtime_context_for()` remains for callers that hold only a dict (a control system, an engine mid-run). `PipelineExecutionState` deliberately does not use it.

**Knock-on:** `start_time` became timezone-aware, so both `datetime.now() - self.start_time` sites would have raised `TypeError`. They now share `_elapsed_seconds()`, with a test.

## 2. Execution ids collided

`f"{pipeline.id}_{int(time.time())}"` is unique only until the same pipeline starts twice inside one second — routine under a test suite, a scheduler, or a retry loop. Since the id names checkpoints, a collision meant the second run resumed from the first one's state.

`new_execution_id()` keeps the sortable, readable stamp and adds entropy. It still starts with the pipeline id, because that is what makes a log line traceable.

## 3/4. The language depended on which engine ran the pipeline

`RuntimeContext.public_names()` is now the single builder every engine consumes. It emits exactly the declared language — the `execution` namespace plus `pipeline_id`, `execution_id`, `timestamp` — and a test asserts that set equality, so the builder cannot drift from what the validators accept.

Before: the declarative engine offered `start_time` and no `timestamp`, and neither engine populated the bare names.

The phantom `pipeline` namespace was in **three** places, not one — `control_flow_engine.py:94` had it too. Both are gone. A repo-wide test now fails if `pipeline`, `context` or `env` is repopulated anywhere under `src/`, since a pipeline written against them runs on that engine and cannot be validated anywhere.

## 5. A resumed run is now the same run

The identity was never exported, so restoring a checkpoint produced a new id and start time — artifacts written after the checkpoint stamped differently from those written before it, in the one situation where you most want them to line up. Checkpoints written before start times carried a zone still load.

## Verification

- 6 mutations, each a faithful inverse of a change, all caught. Restoring each one returned the suite to green.
- Blocking suite: **744 passed**, 13 skipped, 0 failed (was 731).
- `ruff check src/orchestrator --select E9,F63,F7,F82,F821,F823,F601,F811`: clean.
- Catalogue: **50/117**, unchanged — this PR is a correctness fix, not a count-mover.

Not in this PR: the scope-aware reference extraction, which is a validator change and gets its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)