### PR TITLE
Refuse a pull request that does not target main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,34 @@ env:
   ORCHESTRATOR_AUTO_INSTALL: "0"
 
 jobs:
+  pr-base:
+    name: Pull request targets main
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Base branch must be main
+        # #452, #453 and #455 were each merged into a feature branch that had
+        # itself already been merged and deleted. GitHub reported MERGED for
+        # all three and none of the work reached main; it was found later by
+        # checking file contents, not badges.
+        #
+        # The badge cannot distinguish "merged into main" from "merged into a
+        # dead branch". This can, before the merge rather than after it.
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$BASE_REF" != "main" ]; then
+            echo "::error::This pull request targets '$BASE_REF', not 'main'."
+            echo ""
+            echo "Merging into a base that is itself unmerged -- or already"
+            echo "merged and deleted -- reports MERGED while the work never"
+            echo "reaches main. That silently discarded three PRs."
+            echo ""
+            echo "Retarget to main, or keep this a draft until its parent lands."
+            exit 1
+          fi
+          echo "Base branch is 'main'."
+
   lint:
     name: Lint and package metadata
     runs-on: ubuntu-latest


### PR DESCRIPTION
The mechanical version of a discipline I have been applying by hand.

## What it prevents

#452, #453 and #455 were each merged into a feature branch that had itself already been merged and deleted. GitHub reported **MERGED** for all three. None of the work reached `main`. It was found later by checking file contents against `origin/main` — `git cat-file -e origin/main:<path>` — rather than by trusting the badge.

The badge cannot distinguish "merged into main" from "merged into a dead branch". This check can, and it runs *before* the merge rather than after it.

Root cause was stacking three PRs deep and merging them in what looked like the natural order.

## The check

One job, gated to pull requests, failing when `base_ref != main` with a message explaining the failure mode rather than just the condition.

`base_ref` is passed through `env` rather than interpolated into the shell body — branch names are attacker-controllable from forks, so `${{ github.base_ref }}` inside `run:` would be a script-injection hole.

## Verification

- Workflow parses; the guard accepts `main` and rejects `epic/some-feature`, `fix/already-merged-branch`, and `main; echo INJECTED` (the last reaching the comparison as one literal string, not as shell).
- This PR targets `main`, so the new check should pass on itself.

## Not included

Requiring an independent approval for compiler/runtime/validator changes is branch-protection configuration, not a workflow file. It governs whether this work can merge unreviewed, so it is a repository-owner decision rather than something to grant myself in a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)