### PR TITLE
Report the catalogue by class; gate on names, not on the number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,48 @@ jobs:
           name: coverage
           path: coverage.xml
 
+  catalogue:
+    name: Example catalogue
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install from the lockfile
+        run: uv sync --locked --no-default-groups --group test --python 3.12
+
+      - name: Report the catalogue, fail on a named regression
+        # The headline count is deliberately NOT the contract. It moves for
+        # reasons that are not regressions -- fixing an `enhanced/` twin moves
+        # it by two, retiring a legacy file moves it by one -- so gating on it
+        # would punish ordinary progress and reward deleting hard examples.
+        #
+        # scripts/catalogue_validating.txt names the files that validate. A
+        # file LEAVING that list fails this job. A file joining it does not;
+        # it prints a reminder to run --update.
+        #
+        # The grouped counts are informational: they show where the remaining
+        # work actually is, grouped by what the validator says rather than by
+        # a taxonomy that would drift from it.
+        run: uv run --no-sync python scripts/catalogue_report.py | tee catalogue.txt
+
+      - name: Publish the report to the job summary
+        if: always()
+        run: |
+          {
+            echo '## Example catalogue'
+            echo ''
+            echo '```'
+            cat catalogue.txt || echo '(the catalogue step produced no output)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   legacy-suite:
     name: Legacy suite (non-blocking backlog)
     runs-on: ubuntu-latest

--- a/scripts/catalogue_report.py
+++ b/scripts/catalogue_report.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""What the example catalogue currently does, grouped by why.
+
+The catalogue is a mixture: pipelines that are part of the supported product,
+pipelines written against superseded schemas, `enhanced/` twins of other
+files, and pipelines referencing tools that do not exist. A single number --
+"50 of 117 validate" -- hides all of that, and moves for reasons that are not
+regressions: fixing a twin moves it by two, retiring a legacy file moves it by
+one.
+
+So this reports two different things, and only one of them can fail the build:
+
+* **The supported list.** `scripts/catalogue_validating.txt` names the files
+  that validate today. A file dropping out of it is a regression and fails.
+  A file newly validating is an improvement and does not -- it just prints a
+  reminder to add it.
+
+* **Everything else, grouped by the validator's own first error.** Counts by
+  signature rather than by a taxonomy written down somewhere, because a
+  hand-maintained taxonomy drifts from what the validator actually says and
+  then quietly mis-describes the backlog.
+
+Usage:
+    python scripts/catalogue_report.py             # report; fail on regressions
+    python scripts/catalogue_report.py --update    # rewrite the supported list
+    python scripts/catalogue_report.py --json      # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO / "examples"
+SUPPORTED_LIST = REPO / "scripts" / "catalogue_validating.txt"
+
+#: Collapses the variable parts of an error so that "Tool 'a' not found" and
+#: "Tool 'b' not found" are one signature rather than two.
+_QUOTED = re.compile(r"'[^']*'")
+_NUMBER = re.compile(r"\b\d+\b")
+_BULLET = re.compile(r"^\s+-\s+(.*\S)\s*$")
+
+#: Where the validator's summary list starts. Bullets before it are echoed
+#: source, not findings.
+_FAILED_HEADING = re.compile(r"validation failed", re.I)
+
+#: `2026-08-03 19:52:19 - orchestrator.validation... - ERROR - <message>`.
+#: The timestamp must never reach a signature: it would make every run report
+#: a different set of groups.
+_LOG = re.compile(
+    r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[^-]*- [\w.]+ - (?:ERROR|CRITICAL) - (.*)$"
+)
+
+#: The validator prefixes its messages with the phase that produced them.
+_PHASE = re.compile(r"^Validation error in \w+:\s*")
+
+#: A file that does not parse never reaches the validator, so its output is a
+#: parser traceback plus echoed source lines -- which contain whatever words
+#: the pipeline happened to use, including "error".
+_UNPARSEABLE = re.compile(
+    r"yaml\.(scanner|parser|composer|constructor)|"
+    r"ScannerError|ParserError|ComposerError|"
+    r"could not find expected|found character|mapping values are not allowed",
+    re.I,
+)
+
+
+def example_files() -> List[Path]:
+    return sorted(EXAMPLES.rglob("*.yaml"))
+
+
+def validate(path: Path) -> Tuple[bool, str]:
+    """Run `orchestrator validate` exactly as a user would."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    env["ORCHESTRATOR_AUTO_INSTALL"] = "0"
+    result = subprocess.run(
+        [sys.executable, "-m", "orchestrator.cli", "validate", str(path)],
+        cwd=str(REPO), env=env, capture_output=True, text=True, timeout=300,
+    )
+    return result.returncode == 0, result.stdout + result.stderr
+
+
+def first_error(output: str) -> str:
+    """The validator's own first complaint, with the specifics removed.
+
+    Prefers the bulleted list under "validation failed", because that is the
+    validator speaking. Falls back to the first line mentioning a failure,
+    which is what YAML parse errors and crashes produce -- they never reach
+    the bulleted form, and 22 of the current failures are of that kind.
+    """
+    lines = output.splitlines()
+
+    # 1. The validator's own summary list, when it got far enough to produce
+    #    one. Only bullets *after* the "validation failed" heading count: a
+    #    YAML list item in echoed source is also `  - something`, and matching
+    #    those grouped one file under "id: legacy_tool_usage".
+    start = next(
+        (i for i, line in enumerate(lines) if _FAILED_HEADING.search(line)), None
+    )
+    if start is not None:
+        for line in lines[start + 1:]:
+            match = _BULLET.match(line)
+            if match:
+                return _signature(match.group(1))
+
+    # 2. A file that does not parse never reaches the validator. Checked before
+    #    the log scan because the parser echoes source lines, and a pipeline
+    #    whose prose happens to contain "error" would otherwise be grouped by
+    #    its own text.
+    if _UNPARSEABLE.search(output):
+        return "YAML does not parse"
+
+    # 3. Otherwise the first logged error, without its timestamp.
+    for line in lines:
+        match = _LOG.match(line.strip())
+        if match:
+            return _signature(_PHASE.sub("", match.group(1)))
+
+    return "(no error reported)"
+
+
+def _signature(message: str) -> str:
+    """One error, with its specifics removed so like groups with like.
+
+    Numbers go too: "Schema validation failed: 56 errors" and "...: 4272
+    errors" are one kind of problem, and leaving the count in split a single
+    class across nine rows.
+    """
+    message = _QUOTED.sub("'...'", message.strip())
+    message = _NUMBER.sub("N", message)
+    return message[:90]
+
+
+def compare(
+    supported: List[str], validating: List[str]
+) -> Tuple[List[str], List[str]]:
+    """(files that stopped validating, files that newly validate).
+
+    Only the first is a failure. The second is progress, and making it fail
+    would mean every repaired example broke the build until someone updated a
+    list -- which teaches people to stop repairing examples.
+    """
+    return (
+        sorted(set(supported) - set(validating)),
+        sorted(set(validating) - set(supported)),
+    )
+
+
+def load_supported() -> Optional[List[str]]:
+    if not SUPPORTED_LIST.exists():
+        return None
+    return [
+        line.strip()
+        for line in SUPPORTED_LIST.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+
+def write_supported(paths: List[str]) -> None:
+    SUPPORTED_LIST.write_text(
+        "# Examples that pass `orchestrator validate`.\n"
+        "#\n"
+        "# A file leaving this list is a regression and fails CI. A file\n"
+        "# joining it is an improvement; run:\n"
+        "#     python scripts/catalogue_report.py --update\n"
+        "#\n"
+        "# The count is deliberately not the contract -- see the module\n"
+        "# docstring in scripts/catalogue_report.py.\n"
+        + "".join(f"{p}\n" for p in sorted(paths))
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--update", action="store_true",
+                        help="rewrite the supported list from what validates now")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--jobs", type=int, default=8)
+    args = parser.parse_args()
+
+    files = example_files()
+    if not files:
+        print("no examples found", file=sys.stderr)
+        return 1
+
+    with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        results = list(pool.map(validate, files))
+
+    validating: List[str] = []
+    failures: Dict[str, str] = {}
+    for path, (ok, output) in zip(files, results):
+        rel = str(path.relative_to(REPO))
+        if ok:
+            validating.append(rel)
+        else:
+            failures[rel] = first_error(output)
+
+    if args.update:
+        write_supported(validating)
+        print(f"wrote {SUPPORTED_LIST.relative_to(REPO)} with {len(validating)} entries")
+        return 0
+
+    signatures = Counter(failures.values())
+    supported = load_supported()
+    regressed, gained = compare(supported or [], validating)
+
+    if args.json:
+        # Nothing but JSON on stdout: this used to print the human report
+        # afterwards, so anything parsing it hit "Extra data".
+        print(json.dumps({
+            "total": len(files),
+            "validating": len(validating),
+            "failing": len(failures),
+            "by_signature": dict(signatures.most_common()),
+            "failures": failures,
+            "regressed": regressed,
+            "gained": gained if supported is not None else [],
+        }, indent=2))
+        return 1 if (supported is not None and regressed) else 0
+
+    print(f"catalogue: {len(validating)}/{len(files)} validate\n")
+    print(f"{'count':>5}  first error")
+    print(f"{'-' * 5}  {'-' * 60}")
+    for signature, count in signatures.most_common():
+        print(f"{count:>5}  {signature}")
+
+    if supported is None:
+        print(f"\nno {SUPPORTED_LIST.relative_to(REPO)} yet; create it with --update")
+        return 0
+
+    if gained:
+        print(f"\n{len(gained)} example(s) now validate and are not yet listed:")
+        for path in gained:
+            print(f"  + {path}")
+        print("  run: python scripts/catalogue_report.py --update")
+
+    if regressed:
+        print(f"\n{len(regressed)} example(s) stopped validating:")
+        for path in regressed:
+            print(f"  - {path}: {failures.get(path, 'unknown')}")
+        print("\nThese are listed as working, so this is a regression. The "
+              "headline count is not the contract; these named files are.")
+        return 1
+
+    print(f"\nall {len(supported)} listed example(s) still validate")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/catalogue_validating.txt
+++ b/scripts/catalogue_validating.txt
@@ -1,0 +1,58 @@
+# Examples that pass `orchestrator validate`.
+#
+# A file leaving this list is a regression and fails CI. A file
+# joining it is an improvement; run:
+#     python scripts/catalogue_report.py --update
+#
+# The count is deliberately not the contract -- see the module
+# docstring in scripts/catalogue_report.py.
+examples/auto_tags_demo.yaml
+examples/basic/hello_world.yaml
+examples/code_optimization.yaml
+examples/control_flow_conditional.yaml
+examples/control_flow_dynamic.yaml
+examples/creative_image_pipeline.yaml
+examples/data_processing.yaml
+examples/data_processing_pipeline.yaml
+examples/enhanced/code_optimization_enhanced.yaml
+examples/enhanced/control_flow_conditional_enhanced.yaml
+examples/enhanced/control_flow_dynamic_enhanced.yaml
+examples/enhanced/data_processing_enhanced.yaml
+examples/enhanced/data_processing_pipeline_enhanced.yaml
+examples/enhanced/interactive_pipeline_enhanced.yaml
+examples/enhanced/llm_routing_pipeline_enhanced.yaml
+examples/enhanced/mcp_integration_pipeline_enhanced.yaml
+examples/enhanced/mcp_memory_workflow_enhanced.yaml
+examples/enhanced/mcp_simple_test_enhanced.yaml
+examples/enhanced/research_basic_enhanced.yaml
+examples/enhanced/research_minimal_enhanced.yaml
+examples/enhanced/simple_data_processing_enhanced.yaml
+examples/enhanced/simple_timeout_test_enhanced.yaml
+examples/enhanced/statistical_analysis_enhanced.yaml
+examples/enhanced/terminal_automation_enhanced.yaml
+examples/enhanced/validation_pipeline_enhanced.yaml
+examples/enhanced/working_web_search_enhanced.yaml
+examples/interactive_pipeline.yaml
+examples/llm_routing_pipeline.yaml
+examples/mcp_integration_pipeline.yaml
+examples/mcp_memory_workflow.yaml
+examples/mcp_simple_test.yaml
+examples/research_advanced_tools.yaml
+examples/research_basic.yaml
+examples/research_minimal.yaml
+examples/simple_data_processing.yaml
+examples/simple_timeout_test.yaml
+examples/statistical_analysis.yaml
+examples/sub_pipelines/data_preprocessing_sub.yaml
+examples/sub_pipelines/sentiment_analysis.yaml
+examples/sub_pipelines/statistical_analysis.yaml
+examples/sub_pipelines/trend_analysis.yaml
+examples/supported/01_hello_filesystem.yaml
+examples/supported/02_parallel_fanout_fanin.yaml
+examples/supported/04_conditions.yaml
+examples/supported/05_reported_failure.yaml
+examples/supported/06_failure_policy.yaml
+examples/supported/07_templates_and_outputs.yaml
+examples/terminal_automation.yaml
+examples/validation_pipeline.yaml
+examples/working_web_search.yaml

--- a/tests/test_catalogue_report.py
+++ b/tests/test_catalogue_report.py
@@ -1,0 +1,168 @@
+"""The catalogue report says what the validator said, and says it the same way twice.
+
+A dashboard nobody can trust is worse than no dashboard: it gets read once,
+found wrong, and then ignored while still occupying a CI slot. Two properties
+carry that trust.
+
+**Determinism.** The first attempt grouped failures by the first line
+mentioning "error", which picked up log timestamps -- so every run produced a
+different set of groups -- and echoed YAML source, so one file was grouped
+under `id: legacy_tool_usage`, a line from its own body.
+
+**The gate is a list of names, not a count.** The headline number moves for
+reasons that are not regressions: repairing an `enhanced/` twin moves it by
+two, retiring a legacy file moves it by one. Gating on it would punish
+ordinary progress and reward deleting the hard examples.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO = Path(__file__).resolve().parent.parent
+SUPPORTED_LIST = REPO / "scripts" / "catalogue_validating.txt"
+
+
+def _module():
+    """Load the script by path; `scripts/` is not an importable package."""
+    spec = importlib.util.spec_from_file_location(
+        "catalogue_report", REPO / "scripts" / "catalogue_report.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+report = _module()
+
+
+# ---------------------------------------------------------------------------
+# The signature is what the validator said
+# ---------------------------------------------------------------------------
+
+def test_the_validators_own_finding_is_used():
+    output = """
+Validation ✗ FAILED (STRICT)
+Failed to compile YAML: Pipeline validation failed:
+  - Undefined variable: 'ghost'
+  - Undefined task reference: 'rows'
+"""
+    assert report.first_error(output) == "Undefined variable: '...'"
+
+
+def test_a_yaml_list_item_in_echoed_source_is_not_a_finding():
+    """`  - id: legacy_tool_usage` is a line of the pipeline, not a complaint.
+
+    Matching any `  - ...` line grouped one file under its own body text.
+    """
+    output = """
+Reading pipeline:
+  - id: legacy_tool_usage
+    tool: nonexistent
+2026-08-03 19:52:19 - orchestrator.validation.validation_report - ERROR - Validation error in tool: Tool 'nonexistent' not found in registry
+"""
+    assert report.first_error(output) == "Tool '...' not found in registry"
+
+
+def test_a_timestamp_never_reaches_a_signature():
+    """Two runs of the same failure must group together.
+
+    Timestamps in the signature meant every run reported a different set of
+    groups, each of size one.
+    """
+    template = (
+        "%s - orchestrator.validation.validation_report - ERROR - "
+        "Validation error in template: Undefined variable: 'x'"
+    )
+    first = report.first_error(template % "2026-08-03 19:52:19")
+    second = report.first_error(template % "2026-08-04 07:15:02")
+
+    assert first == second, f"{first!r} != {second!r}; a run stamp leaked in"
+    assert "2026" not in first
+
+
+def test_a_file_that_does_not_parse_is_reported_as_such():
+    """The parser echoes source, and a pipeline whose prose contains the word
+    "error" would otherwise be grouped by its own text."""
+    output = """
+Failed to compile YAML: Invalid YAML:
+  in "<unicode string>", line 117, column 5
+117:     error_handling: continue
+yaml.scanner.ScannerError: mapping values are not allowed here
+"""
+    assert report.first_error(output) == "YAML does not parse"
+
+
+def test_counts_inside_a_message_are_normalised():
+    """"Schema validation failed: 56 errors" and "...: 4272 errors" are one
+    kind of problem; leaving the count in split it across nine rows."""
+    def sig(n):
+        return report.first_error(
+            f"validation failed:\n  - Compilation failed: "
+            f"Schema validation failed: {n} errors"
+        )
+
+    assert sig(56) == sig(4272)
+    assert "N errors" in sig(56)
+
+
+def test_the_specifics_of_a_name_are_normalised():
+    def sig(name):
+        return report.first_error(
+            f"validation failed:\n  - Tool '{name}' not found in registry"
+        )
+
+    assert sig("debug") == sig("count_words")
+
+
+def test_output_with_no_error_at_all_is_labelled_not_guessed():
+    assert report.first_error("everything went fine\n") == "(no error reported)"
+
+
+# ---------------------------------------------------------------------------
+# The gate is a list of names
+# ---------------------------------------------------------------------------
+
+def test_a_file_leaving_the_list_is_a_regression():
+    regressed, gained = report.compare(["a.yaml", "b.yaml"], ["a.yaml"])
+    assert regressed == ["b.yaml"]
+    assert gained == []
+
+
+def test_a_newly_validating_file_is_not_a_regression():
+    """Failing here would mean every repaired example breaks the build until
+    someone updates a list, which teaches people to stop repairing examples."""
+    regressed, gained = report.compare(["a.yaml"], ["a.yaml", "c.yaml"])
+    assert regressed == []
+    assert gained == ["c.yaml"]
+
+
+def test_a_swap_of_equal_size_is_still_a_regression():
+    """The count is unchanged here, which is exactly why the count is not the
+    contract."""
+    regressed, gained = report.compare(["a.yaml", "b.yaml"], ["a.yaml", "c.yaml"])
+    assert regressed == ["b.yaml"]
+    assert gained == ["c.yaml"]
+
+
+# ---------------------------------------------------------------------------
+# The committed list describes this repository
+# ---------------------------------------------------------------------------
+
+def test_every_listed_example_exists():
+    """A stale entry would fail CI forever with a confusing message."""
+    missing = [
+        line for line in SUPPORTED_LIST.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+        and not (REPO / line.strip()).exists()
+    ]
+    assert not missing, f"listed but not present: {missing}"
+
+
+def test_the_list_is_not_empty():
+    assert report.load_supported(), (
+        "an empty supported list would make the regression gate vacuous"
+    )


### PR DESCRIPTION
Implements the catalogue dashboard, built around the review's warning: *avoid making "number validating" the sole success measure, and track supported runnable examples separately from legacy catalogue health.*

## Why the number cannot be the contract

It moves for reasons that are not regressions. Repairing an `enhanced/` twin moves it by two; retiring a legacy file moves it by one; an equal-sized swap does not move it at all. Gating on it would punish ordinary progress and reward deleting the hard examples.

## Two things, one of which can fail the build

**`scripts/catalogue_validating.txt`** names the 50 files that validate today.

- A file **leaving** the list fails the job, naming it and quoting its error.
- A file **joining** it does not fail — it prints a reminder to run `--update`. Failing here would mean every repaired example breaks the build until someone updates a list, which teaches people to stop repairing examples.
- An **equal-sized swap** still fails, which is precisely what a count-based gate would miss.

**The grouped report** counts failures by the validator's own first error, published to the CI job summary. Grouping by what the validator actually says, rather than by a hand-written taxonomy, means it cannot drift into mis-describing the backlog.

```
catalogue: 50/117 validate

count  first error
-----  ------------------------------------------------------------
   27  Undefined variable: '...'
   13  Compilation failed: Schema validation failed: N errors
    8  Tool '...' not found in registry
    6  Task '...' for_each references non-existent task '...'
    4  Task '...' depends on non-existent task '...'
    3  YAML does not parse
    2  Error processing file inclusions: File not found: path...
    2  Compilation failed: Invalid YAML: ...after AUTO tag processing
    1  Compilation failed: Failed to render template '...': dict object has no element N
    1  Compilation failed: Failed to render template '...': int() argument must be...
```

All 67 failures group into 10 signatures with nothing falling through.

## The three wrong versions are why the tests exist

Trustworthiness here is mostly about determinism, and the first two attempts had none:

1. Grouping by "the first line mentioning *error*" picked up **log timestamps**, so every run produced a different set of groups, each of size one.
2. Matching any `  - ...` line matched **YAML list items in echoed source**, filing one pipeline under `id: legacy_tool_usage` — a line from its own body.
3. Leaving counts in the message split `Schema validation failed: N errors` across **nine rows**.

Each is now a test. A dashboard nobody trusts is worse than none: it gets read once, found wrong, then ignored while still occupying a CI slot.

## Two bugs the gate test found in my own script

Verifying the gate actually fires — rather than assuming — turned up:

- `--json` printed the human report **after** the JSON, so anything parsing it hit `Extra data`. It now emits nothing but JSON and carries `regressed`/`gained`.
- My first gate test injected an **empty string** into the list and "passed" vacuously.

Confirmed properly: injecting a genuinely-failing example makes the script exit 1 and name it; removing it returns to exit 0.

## Verification

- 12 unit tests for the report logic; blocking suite **792 passed**, 0 failed; lint clean.
- Job capped at 25 minutes and does not touch the network or any provider.

## Relationship to issue #104

#104 holds a *judgement* triage (duplicate / legacy / unsupported / repairable) — a human reading of what should happen to each file. This script reports the *mechanical* grouping. They answer different questions, and only the mechanical one can be kept current automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)